### PR TITLE
Make shader files part of their corresponding build projects, rebuild on demand

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -84,3 +84,5 @@ endif()
 add_subdirectory(app)
 
 add_subdirectory(antora)
+
+compile_all_shaders()

--- a/bldsys/cmake/sample_helper.cmake
+++ b/bldsys/cmake/sample_helper.cmake
@@ -20,11 +20,11 @@
 set(SCRIPT_DIR ${CMAKE_CURRENT_LIST_DIR})
 
 function(add_sample)
-    set(options NO_SHADERS)  
+    set(options NO_SHADERS)
     set(oneValueArgs ID CATEGORY AUTHOR NAME DESCRIPTION SPIRV_VERSION)
     set(multiValueArgs TAGS FILES LIBS SHADER_FILES_GLSL SHADER_FILES_HLSL)
 
-    cmake_parse_arguments(TARGET "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})    
+    cmake_parse_arguments(TARGET "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
 
     set(options NO_SHADERS)
     set(oneValueArgs ID CATEGORY AUTHOR NAME DESCRIPTION SPIRV_VERSION)
@@ -62,7 +62,7 @@ function(add_sample)
         AUTHOR ${TARGET_AUTHOR}
         NAME ${TARGET_NAME}
         DESCRIPTION ${TARGET_DESCRIPTION}
-        TAGS 
+        TAGS
             ${TARGET_TAGS}
         FILES
             ${SRC_FILES}
@@ -110,7 +110,7 @@ function(vkb_add_test)
 endfunction()
 
 function(add_project)
-    set(options)  
+    set(options)
     set(oneValueArgs TYPE ID CATEGORY AUTHOR NAME DESCRIPTION SPIRV_VERSION)
     set(multiValueArgs TAGS FILES LIBS SHADERS_GLSL SHADERS_HLSL)
 
@@ -127,37 +127,16 @@ function(add_project)
 
     message(STATUS "${TARGET_TYPE} `${TARGET_ID}` - BUILD")
 
-    set(TARGET_DIR ${CMAKE_SOURCE_DIR})
-
     # create project (object target - reused by app target)
     project(${TARGET_ID} LANGUAGES C CXX)
 
     source_group("\\" FILES ${TARGET_FILES})
 
-    # Add shaders to project group
-    if (TARGET_SHADERS_GLSL)
-        list(APPEND SOURCE_SHADER_FILES)
-        foreach(GLSL_FILE ${TARGET_SHADERS_GLSL})
-            list(APPEND SOURCE_SHADER_FILES "${TARGET_DIR}/shaders/${GLSL_FILE}")
-        endforeach()   
+    if(${TARGET_TYPE} STREQUAL "Sample")
+        add_library(${PROJECT_NAME} OBJECT ${TARGET_FILES})
+    elseif(${TARGET_TYPE} STREQUAL "Test")
+        add_library(${PROJECT_NAME} STATIC ${TARGET_FILES})
     endif()
-
-    if (TARGET_SHADERS_HLSL)
-        list(APPEND SOURCE_SHADER_FILES)
-        foreach(HLSL_FILE ${TARGET_SHADERS_HLSL})
-            list(APPEND SOURCE_SHADER_FILES "${TARGET_DIR}/shaders/${HLSL_FILE}")
-        endforeach()   
-    endif()
-    
-    if (SOURCE_SHADER_FILES)
-        source_group("\\Shaders" FILES ${SOURCE_SHADER_FILES})
-    endif()
-
-if(${TARGET_TYPE} STREQUAL "Sample")
-    add_library(${PROJECT_NAME} OBJECT ${TARGET_FILES} ${SOURCE_SHADER_FILES})
-elseif(${TARGET_TYPE} STREQUAL "Test")
-    add_library(${PROJECT_NAME} STATIC ${TARGET_FILES} ${SOURCE_SHADER_FILES})
-endif()
     set_target_properties(${PROJECT_NAME} PROPERTIES POSITION_INDEPENDENT_CODE ON)
 
     # # inherit include directories from framework target
@@ -169,7 +148,7 @@ endif()
         target_link_libraries(${PROJECT_NAME} PUBLIC ${TARGET_LIBS})
     endif()
 
-    # capitalise the first letter of the category  (performance -> Performance) 
+    # capitalise the first letter of the category  (performance -> Performance)
     string(SUBSTRING ${TARGET_CATEGORY} 0 1 FIRST_LETTER)
     string(TOUPPER ${FIRST_LETTER} FIRST_LETTER)
     string(REGEX REPLACE "^.(.*)" "${FIRST_LETTER}\\1" CATEGORY "${TARGET_CATEGORY}")
@@ -177,7 +156,7 @@ endif()
     if(${TARGET_TYPE} STREQUAL "Sample")
         # set sample properties
         set_target_properties(${PROJECT_NAME}
-            PROPERTIES 
+            PROPERTIES
                 SAMPLE_CATEGORY ${TARGET_CATEGORY}
                 SAMPLE_AUTHOR ${TARGET_AUTHOR}
                 SAMPLE_NAME ${TARGET_NAME}

--- a/framework/CMakeLists.txt
+++ b/framework/CMakeLists.txt
@@ -78,7 +78,7 @@ set(COMMON_FILES
     common/ktx_common.h
     common/vk_common.h
     common/vk_initializers.h
-    common/glm_common.h 
+    common/glm_common.h
     common/resource_caching.h
     common/logging.h
     common/helpers.h
@@ -387,7 +387,7 @@ set(LINUX_D2D_FILES
     platform/unix/direct_window.h
     # Source Files
     platform/unix/unix_d2d_platform.cpp
-    platform/unix/direct_window.cpp) 
+    platform/unix/direct_window.cpp)
 
 source_group("\\" FILES ${FRAMEWORK_FILES})
 source_group("common\\" FILES ${COMMON_FILES})
@@ -454,6 +454,14 @@ endif()
 #NB: switch this to shared library and things stop working. (there is likely two copies of volk somewhere.
 add_library(${PROJECT_NAME} OBJECT ${PROJECT_FILES})
 set_target_properties(${PROJECT_NAME} PROPERTIES POSITION_INDEPENDENT_CODE ON)
+
+# Compile common shaders
+compile_shaders(
+    ID ${PROJECT_NAME}
+    SHADER_FILES_GLSL
+        "imgui.vert"
+        "imgui.frag"
+)
 
 # compiler flags based on compiler type
 if(NOT MSVC)

--- a/samples/CMakeLists.txt
+++ b/samples/CMakeLists.txt
@@ -127,14 +127,14 @@ set(ORDER_LIST
 	"hpp_terrain_tessellation"
 	"hpp_texture_loading"
 	"hpp_texture_mipmap_generation"
-	
+
 	#HPP Extension Samples
 	"hpp_mesh_shading"
-	
+
     #HPP Performance Samples
     "hpp_pipeline_cache"
     "hpp_swapchain_images"
-    
+
     #General Samples
     "mobile_nerf")
 
@@ -160,12 +160,3 @@ endforeach ()
 
 # Make sample list visible parent scope (required by vulkan_samples project)
 set(TOTAL_SAMPLE_ID_LIST ${ORDERED_LIST} PARENT_SCOPE)
-
-# Compile common shaders
-
-compile_shaders(
-    ID vkb__shaders
-    SHADER_FILES_GLSL
-        "imgui.vert"
-        "imgui.frag"
-)


### PR DESCRIPTION
I may have gotten a little carried away.

* Removes all shader handling (source and SPV) from sample_helper.cmake and moved to `compile_shaders`.  This means `compile_shaders` can be used with anything whether it goes through `add_sample` or `add_library`.
* Refactored `compile_shaders` in terms of `filter_shaders` and `compile_shader` macro, reducing duplicated code
* If building is possible, then the generated SPV files will be added to the project and automatically recompiled on project build when the SPV is out of date relative to its source file
* Removed `add_custom_target(vkb__shaders)`  and pushed the `imgui` shaders to be part of `framework`, since that's where the GUI code lives for now.

TODO:

The `${CMAKE_COMMAND} -E copy "${SHADER_FILE_SPV}" "${STORED_SHADER_FILE_SPV}"` should probably be factored out of the existing custom commands and into its own.  It has a different OUTPUT and DEPENDS than the other portions of the actual compile commands.  It should probably also be encased in some kind of CMake flag set at the command line, since most people using this repository don't want that copy to happen.  If they have a different SDK version it could produce different SPIR-V and thus make a bunch of shader files suddenly look like they've changed from the perspective of source control.

It should also be possible to be more precise in the DEPENDS for the command, at least for GLSL.  If a shader uses any include files, we want changes to them to also trigger rebuild of a given SPV.  [This](https://old.reddit.com/r/vulkan/comments/1avm0fg/how_to_compile_shaders_with_cmake_that_one_game/krfqy89/) comment on reddit could serve as a starting point for that, unless there's similar functionality in `glslc`.

